### PR TITLE
Logging improvements

### DIFF
--- a/obs/face/annotate/BeliefPropagationChain.py
+++ b/obs/face/annotate/BeliefPropagationChain.py
@@ -141,7 +141,7 @@ class BeliefPropagationChain:
         l = [0] * n
         while continue_enumeration:
             # for i in range(n):
-            #     print(l[i], end=" ")
+            #     log.debug(l[i], end=" ")
 
             p = 1.0
             for i in range(n):
@@ -150,7 +150,7 @@ class BeliefPropagationChain:
             for i in range(n - 1):
                 p *= self.psi[i][l[i]][l[i + 1]]
 
-            # print(p)
+            # log.debug(p)
 
             if p > p_best:
                 p_best = p

--- a/obs/face/geojson/ExportMeasurements.py
+++ b/obs/face/geojson/ExportMeasurements.py
@@ -3,6 +3,7 @@ import os
 import logging
 import math
 
+log = logging.getLogger(__name__)
 
 class ExportMeasurements:
     def __init__(self, filename, do_filter=True):
@@ -75,7 +76,7 @@ class ExportMeasurements:
             self.features.append(feature)
 
     def finalize(self):
-        logging.info("{} samples, {} valid ({} valid lat/lon, {} valid distance, {} confirmed)"\
+        log.info("{} samples, {} valid ({} valid lat/lon, {} valid distance, {} confirmed)"\
                      .format(self.n_samples, self.n_valid, self.n_valid_latlon, self.n_valid_dist, self.n_confirmed))
 
         data = {"type": "FeatureCollection",
@@ -83,6 +84,6 @@ class ExportMeasurements:
 
         os.makedirs(os.path.dirname(self.filename), exist_ok=True)
 
-        logging.info("writing GeoJSON file " + self.filename)
+        log.info("writing GeoJSON file " + self.filename)
         with open(self.filename, 'w') as f:
             json.dump(data, f)

--- a/obs/face/geojson/ExportMeasurements.py
+++ b/obs/face/geojson/ExportMeasurements.py
@@ -76,14 +76,14 @@ class ExportMeasurements:
             self.features.append(feature)
 
     def finalize(self):
-        log.info("{} samples, {} valid ({} valid lat/lon, {} valid distance, {} confirmed)"\
-                     .format(self.n_samples, self.n_valid, self.n_valid_latlon, self.n_valid_dist, self.n_confirmed))
+        log.info("%s samples, %s valid (%s valid lat/lon, %s valid distance, %s confirmed)",
+                  self.n_samples, self.n_valid, self.n_valid_latlon, self.n_valid_dist, self.n_confirmed)
 
         data = {"type": "FeatureCollection",
                 "features": self.features}
 
         os.makedirs(os.path.dirname(self.filename), exist_ok=True)
 
-        log.info("writing GeoJSON file " + self.filename)
+        log.info("writing GeoJSON file %s", self.filename)
         with open(self.filename, 'w') as f:
             json.dump(data, f)

--- a/obs/face/geojson/ExportRoadAnnotations.py
+++ b/obs/face/geojson/ExportRoadAnnotations.py
@@ -5,6 +5,7 @@ import logging
 
 from obs.face.mapping import AzimuthalEquidistant as LocalMap
 
+log = logging.getLogger(__name__)
 
 class ExportRoadAnnotation:
     def __init__(self, filename, osm, right_hand_traffic=True):
@@ -46,7 +47,7 @@ class ExportRoadAnnotation:
                 self.n_grouped += 1
 
     def finalize(self):
-        logging.info("{} samples, {} valid".format(self.n_samples, self.n_valid))
+        log.info("{} samples, {} valid".format(self.n_samples, self.n_valid))
         features = []
         for way in self.way_statistics.values():
             way.finalize()

--- a/obs/face/geojson/ExportRoadAnnotations.py
+++ b/obs/face/geojson/ExportRoadAnnotations.py
@@ -47,7 +47,7 @@ class ExportRoadAnnotation:
                 self.n_grouped += 1
 
     def finalize(self):
-        log.info("{} samples, {} valid".format(self.n_samples, self.n_valid))
+        log.info("%s samples, %s valid", self.n_samples, self.n_valid)
         features = []
         for way in self.way_statistics.values():
             way.finalize()

--- a/obs/face/mapping/Roads.py
+++ b/obs/face/mapping/Roads.py
@@ -7,6 +7,8 @@ from .LocalMap import AzimuthalEquidistant as LocalMap
 from .RoadContainerAABBtree import RoadContainerAABBtree as RoadContainer
 from .Way import Way
 
+log = logging.getLogger(__name__)
+
 class Roads:
     def __init__(self, osm, d_max=10.0, d_phi_max=40.0, cache_dir='cache'):
         self.d_max = d_max
@@ -16,11 +18,11 @@ class Roads:
 
         self.create_roads_cached = self.memory.cache(self.create_roads, ignore=['self', 'osm'])
 
-        logging.info("creating road data structure")
+        log.info("creating road data structure")
         lat_0, lon_0 = osm.get_map_center()
         self.local_map = LocalMap(lat_0, lon_0)
         self.roads = self.create_roads_cached(osm, osm.data_id)
-        logging.info("finished road data structure")
+        log.info("finished road data structure")
 
     def __del__(self):
         pass

--- a/obs/face/osm/DataSource.py
+++ b/obs/face/osm/DataSource.py
@@ -4,6 +4,7 @@ import logging
 
 from joblib import Memory
 
+log = logging.getLogger(__name__)
 
 class DataSource:
     def __init__(self, areas=None, cache_dir="cache", query_family="roads_in_admin_boundary"):
@@ -43,7 +44,7 @@ class DataSource:
         # construct the query
         query = self.query_templates[name_query].format(name_pattern=name_pattern)
 
-        logging.debug("sending query to self.overpass_url\m" + query)
+        log.debug("sending query to self.overpass_url\m" + query)
 
         # send it and receive answer
         response = self.get_cached(self.overpass_url,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests==2.25.1
 aabbtree==2.6.2
 jsons==1.3.0
 memoization==0.3.2
+coloredlogs==15.0


### PR DESCRIPTION
* Use python logging instead of print where applicable
* Create loggers instead of using global static functions
* Use `coloredlogs` package to format logs nicely
* Prefer logging's format string patterns instead of manually formating messages (best practice)

We could also replace the log streams in `obs.face.importer` and `MeasurementFilter` with logger objects that write into a file... would be a bit cleaner still.