### PR TITLE
Don't be too picky about tag case

### DIFF
--- a/obs/face/annotate/AnnotateMeasurements.py
+++ b/obs/face/annotate/AnnotateMeasurements.py
@@ -65,11 +65,11 @@ class AnnotateMeasurements:
             tags = way.tags
             if "zone:traffic" in tags:
                 zone = tags["zone:traffic"]
-                if zone == "DE:urban":
+                if zone.lower() == "de:urban":
                     zone = "urban"
-                elif zone == "DE:rural":
+                elif zone.lower() == "de:rural":
                     zone = "rural"
-                elif zone == "DE:motorway":
+                elif zone.lower() == "de:motorway":
                     zone = "motorway"
                 m["OSM_zone"] = zone
 


### PR DESCRIPTION
OSMers are not always respecting case when tagging - but clearly ``DE:rural`` and ``de:rural`` can only mean the same thing, so we can safely be case-insensitive here.
@FlorusCiphersmith @mentioning you because I guess you will be an adequate reviewer and probably have the required permissions.