### PR TITLE
Switch to vanilla OSM maps with greyscale filter

### DIFF
--- a/visualization/measurements.html
+++ b/visualization/measurements.html
@@ -34,6 +34,9 @@ along with the OpenBikeSensor Scripts Collection.  If not, see
     top: 0px;
     z-index: 0;
     }
+    .bw {
+    filter: greyscale(100%) opacity(50%);
+    }
 	  .overlay{
 	  display: flex;
 	  flex-direction: column;
@@ -216,11 +219,11 @@ along with the OpenBikeSensor Scripts Collection.  If not, see
     target: 'map',
     layers: [
     new ol.layer.Tile({
+    className: "bw",
     source: new ol.source.OSM({
-    url: 'https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png',
     // url: 'https://{a-c}.tile-cyclosm.openstreetmap.fr/cyclosm-lite/{z}/{x}/{y}.png',
-    crossOrigin: null
-    // url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+    crossOrigin: null,
+    url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
     })
     })
     ],

--- a/visualization/roads.html
+++ b/visualization/roads.html
@@ -36,6 +36,10 @@ along with the OpenBikeSensor Scripts Collection.  If not, see
 			z-index: 0;
 		}
 
+		.bw {
+		    filter: greyscale(100%) opacity(50%);
+		}
+
 		.overlay {
 			display: flex;
 			flex-direction: column;
@@ -346,10 +350,10 @@ along with the OpenBikeSensor Scripts Collection.  If not, see
 			target: 'map',
 			layers: [
 				new ol.layer.Tile({
+				    className: "bw",
 					source: new ol.source.OSM({
-						url: 'https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png',
-						crossOrigin: null
-						// url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+						crossOrigin: null,
+						url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
 					})
 				})
 			],


### PR DESCRIPTION
``tiles.wmflabs.org`` discontinued service, resulting in the maps looking like this:
![image](https://user-images.githubusercontent.com/44007906/150693708-40b881e7-b715-4ba4-89ed-2a6c275d19fd.png)
